### PR TITLE
changed the default format so the extension is unnecessary.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 RsstubeRails::Application.routes.draw do
-  get "/:channel_name", to:'feed#for_channel'
+  get "/:channel_name", to:'feed#for_channel', :defaults => { :format => 'atom' }
   root to:'feed#index'
 end


### PR DESCRIPTION
Allows you to now simply enter rsstube.net/skierdb526 into one's RSS reader.
